### PR TITLE
fix: pushbullet integration

### DIFF
--- a/src/utils/pushBullet.js
+++ b/src/utils/pushBullet.js
@@ -1,4 +1,4 @@
-const PushBullet = require('pushbullet');
+const PushBullet = require('@jef/pushbullet');
 
 // Strip tags is to remove HTML before sending to Pushbullet.
 const striptags = require('striptags');


### PR DESCRIPTION
413db0409db45142c4dd88451cb0b9268ed7ae1d introduced a regression where the application no longer starts with the following error:

```
Error: Cannot find module 'pushbullet'
Require stack:
- /app/src/utils/pushBullet.js
- /app/src/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:925:15)
    at Function.Module._load (node:internal/modules/cjs/loader:769:27)
    at Module.require (node:internal/modules/cjs/loader:997:19)
    at require (node:internal/modules/cjs/helpers:92:18)
    at Object.<anonymous> (/app/src/utils/pushBullet.js:1:20)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Module.require (node:internal/modules/cjs/loader:997:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/app/src/utils/pushBullet.js', '/app/src/index.js' ]
}
```

This PR will fix dependency reference to ensure that the application can start successfully.