### PR TITLE
improved docker documentation for first time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ You can install and run AlertHub with some simple steps:
 
 ## Docker Container
 
+First, you need to get the example config file and modify it accordingly, either get a copy from [this repo](./etc/config.example.js), or with the following command:
+```
+docker run --rm ghcr.io/ardakilic/alerthub:2 cat /usr/src/app/etc/config.js > /host/path/config.js
+```
+
 To run
 
 ```


### PR DESCRIPTION
as per the title, I improved a bit the documentation for docker user, explaining how to get the config file to avoid the following error at startup if launched with an empty config file
```
Application booted at Thu, 05 Sep 2024 14:16:09 GMT
file:///usr/src/app/src/index.mjs:22
Object.keys(config.repositories.github).forEach((type) => {
                                ^

TypeError: Cannot read properties of undefined (reading 'github')
    at file:///usr/src/app/src/index.mjs:22:33
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:527:24)
    at async loadESM (node:internal/process/esm_loader:91:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)

Node.js v18.9.1
```

or the following if launched without a file present at `/usr/src/app/etc/config.js` at all
```
Application booted at Thu, 05 Sep 2024 14:16:36 GMT
file:///usr/src/app/src/index.mjs:22
Object.keys(config.repositories.github).forEach((type) => {
                                ^

TypeError: Cannot read properties of undefined (reading 'github')
    at file:///usr/src/app/src/index.mjs:22:33
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:527:24)
    at async loadESM (node:internal/process/esm_loader:91:5)
    at async handleMainPromise (node:internal/modules/run_main:65:12)

Node.js v18.9.1
```